### PR TITLE
Add new mail chimp form

### DIFF
--- a/lib/erlef_web/templates/page/index.html.eex
+++ b/lib/erlef_web/templates/page/index.html.eex
@@ -7,30 +7,30 @@
                 </p>
 
                 </script>
-                <!-- TODO: Get a new mail chimp form builder thingy -->
-                <form id="mc4wp-form-1" class="mc4wp-form mc4wp-form-116" method="post" data-id="116" data-name="">
-                    <div class="mc4wp-form-fields">
-                        <div class="subscribe">
+              <div>
+                <form action="https://erlef.us20.list-manage.com/subscribe/post?u=8d8ff4d9284d463c374e574bb&amp;id=8cad7357f8" 
+                    method="post" id="mc-embedded-subscribe-form" 
+                                  name="mc-embedded-subscribe-form" 
+                                  class="validate mc4wp-form mc4wp-form-116" 
+                                  target="_blank" novalidate>    
+                    <div class="mc-form-fields">
+                      <div style="position: absolute; left: -5000px;" aria-hidden="true">
+                        <input type="text" name="b_8d8ff4d9284d463c374e574bb_8cad7357f8" tabindex="-1" value="">
+                      </div>
+ 
+                      <div class="subscribe">
+                        <p class="col-xs-4 col-md-4 col-lg-4" style="padding-left: 0">
+                            <input type="email" name="EMAIL" placeholder="Your e-mail address" required="">
+                        </p>
 
-                            <p class="col-xs-4 col-md-4 col-lg-4" style="padding-left: 0">
-                                <input type="email" name="EMAIL" placeholder="Your e-mail address" required="">
-                            </p>
-
-                            <p class="col-xs-4 col-md-4 col-lg-4 mailform" style="padding-left: 0">
-                                <input style="border-color: #BBBBBB; width: 100%;" type="submit" value="Subscribe">
-                            </p>
-                        </div>
+                        <p class="col-xs-4 col-md-4 col-lg-4 mailform" style="padding-left: 0">
+                          <input style="border-color: #BBBBBB; width: 100%;" type="submit" value="Subscribe">
+                        </p>
                     </div>
-                    <label style="display: none !important;">Leave this field empty if you're human:
-                        <input type="text" name="_mc4wp_honeypot" value="" tabindex="-1" autocomplete="off" />
-                    </label>
-                    <input type="hidden" name="_mc4wp_timestamp" value="1559954148" />
-                    <input type="hidden" name="_mc4wp_form_id" value="116" />
-                    <input type="hidden" name="_mc4wp_form_element_id" value="mc4wp-form-1" />
-                    <div class="mc4wp-response"></div>
+                  </div>    
                 </form>
-                <!-- / Mailchimp -->
-            </div>
+            </div> 
+            <!-- / Mailchimp -->
         </div>
     </section>
 


### PR DESCRIPTION
 The notable difference between this version and the current version on WP is this will not redirect you back to the site. Instead, it will open a new tab with confirmation etc. If the redirect is highly desirable right now then I can adjust but I'd rather ship it then worry about those detail; especially taking into consideration that others involved in the design will have a say-so in these matters.

<img width="845" alt="image" src="https://user-images.githubusercontent.com/39971740/62130750-4e9d8100-b29f-11e9-9b8b-e4dad68f5bb6.png">

Closes #27 
