### PR TITLE
use news index for eef category

### DIFF
--- a/lib/erlef_web/controllers/blog_controller.ex
+++ b/lib/erlef_web/controllers/blog_controller.ex
@@ -5,9 +5,9 @@ defmodule ErlefWeb.BlogController do
   alias Erlef.Blogs
 
   # not sure what we want to do with this yet.
-  def index(conn, %{"topic" => topic}) do
-    with {:ok, posts} <- list(topic) do
-      render(conn, "index.html", topic: topic, posts: posts)
+  def index(conn, _params) do
+    with {:ok, posts} <- list("eef") do
+      render(conn, "index.html", topic: "eef", about: "eh", posts: posts)
     else
       _ -> {:error, :not_found}
     end
@@ -34,7 +34,7 @@ defmodule ErlefWeb.BlogController do
 
   defp fetch_working_group(_), do: nil
 
-  defp list(_name) do
-    []
+  defp list(name) do
+    {:ok, Erlef.Blogs.Repo.for_wg(name)}
   end
 end

--- a/lib/erlef_web/router.ex
+++ b/lib/erlef_web/router.ex
@@ -26,6 +26,7 @@ defmodule ErlefWeb.Router do
     get "/become-a-sponsor", PageController, :sponsor_info
     get "/wg-proposal-template", PageController, :wg_proposal_template
 
+    get "/news",  BlogController, :index, as: :news
     get "/news/:id", BlogController, :show, as: :news
 
     resources "/events", EventController, only: [:index, :show]

--- a/lib/erlef_web/templates/blog/index.html.eex
+++ b/lib/erlef_web/templates/blog/index.html.eex
@@ -6,7 +6,7 @@
         <h1 class="display-4 font-italic"><%= post1.title %></h1>
         <p class="lead my-3"><%= post1.excerpt %></p>
         <p class="lead mb-0">
-        <%= link("Continuing Reading", to: Routes.news_path(@conn, :show, @topic, post1.slug), class: "stretched") %>
+        <%= link("Continuing Reading", to: Routes.news_path(@conn, :show, post1.slug), class: "stretched") %>
       </div>
     </div>
   <% end %>
@@ -27,7 +27,7 @@
             <h3 class="mb-0"><%= post2.title %></h3>
             <div class="mb-1 text-muted"><%= "#{month2}, #{day2}" %></div>
             <p class="card-text mb-auto truncate"><%= post2.excerpt %></p>
-            <%= link("Continue Reading", to: Routes.news_path(@conn, :show, @topic, post2.slug), class: "stretched") %>
+            <%= link("Continue Reading", to: Routes.news_path(@conn, :show, post2.slug), class: "stretched") %>
           </div>
           <div class="col-auto d-none d-lg-block">
             <svg class="bd-placeholder-img" width="200" height="250" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Thumbnail"><title>Placeholder</title><rect width="100%" height="100%" fill="#55595c"></rect><text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text></svg>
@@ -42,7 +42,7 @@
             <h3 class="mb-0"><%= post3.title %></h3>
             <div class="mb-1 text-muted"><%= "#{month3}, #{day3}" %></div>
             <p class="card-text mb-auto truncate"><%= post3.excerpt %>.</p>
-            <%= link("Continue Reading", to: Routes.news_path(@conn, :show, @topic, post3.slug), class: "stretched") %>
+            <%= link("Continue Reading", to: Routes.news_path(@conn, :show, post3.slug), class: "stretched") %>
           </div>
           <div class="col-auto d-none d-lg-block">
             <svg class="bd-placeholder-img" width="200" height="250" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Thumbnail"><title>Placeholder</title><rect width="100%" height="100%" fill="#55595c"></rect><text x="50%" y="50%" fill="#eceeef" dy=".3em">Thumbnail</text></svg>
@@ -57,7 +57,7 @@
     <div class="col-md-8 blog-main">
       <%= for post <- @posts do %>
         <div class="post-preview">
-          <%= link(to: Routes.news_path(@conn, :show, @topic, post.slug), class: "post-title") do %>
+          <%= link(to: Routes.news_path(@conn, :show, post.slug), class: "post-title") do %>
             <h2><%= post.title %></h2>
           <% end %>
           <h3 class="post-subtitle">Sub-title</h3>

--- a/priv/posts/wg/20190802222421_time-is-running-out.md
+++ b/priv/posts/wg/20190802222421_time-is-running-out.md
@@ -2,7 +2,7 @@
   "title": "Time is running out!",
   "author": "EEF",
   "slug": "time-is-running-out",
-  "category": "wg",
+  "category": "eef",
   "datetime": "2019-07-17T22:24:21.605755Z"
 }
 ---


### PR DESCRIPTION
This PR makes the news index route usable again. Right now it gets all the blog posts and high lights the three latest. We should make this default to  category eef only, though that's a bit odd one would expect the index to show all. 

 All up for discussion. Initial draft view.

<img width="914" alt="image" src="https://user-images.githubusercontent.com/39971740/62573148-f9431000-b85a-11e9-892b-c33444966048.png">
