### PR TITLE
Display UTC timezones as local in event show template

### DIFF
--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', function() {
             navLinks: navLinks,
             themeSystem: 'bootstrap',
             defaultView: defaultView,
-            timezone: "local",
+            timeZone: "UTC",
             visibleRange: function(currentDate) {
                 var startDate = new Date(currentDate.valueOf());
                 var endDate = new Date(currentDate.valueOf());

--- a/lib/erlef_web/plugs/json_events.ex
+++ b/lib/erlef_web/plugs/json_events.ex
@@ -25,6 +25,8 @@ defmodule ErlefWeb.Plug.JsonEvents do
           end
 
         e.metadata
+        |> Map.put("start", apply_time_offset(e.metadata["start"], e.metadata["offset"]))
+        |> Map.put("end", apply_time_offset(e.metadata["end"], e.metadata["offset"]))
         |> Map.put("url", "/events/#{slug}")
         |> Map.put("description", description)
       end)
@@ -40,6 +42,17 @@ defmodule ErlefWeb.Plug.JsonEvents do
       end
     )
   end
+
+  defp apply_time_offset(date_str, "UTC" <> offset) when offset != "" do
+    {:ok, datetime, _} = DateTime.from_iso8601(date_str)
+    {offset_hours, _} = Integer.parse(offset)
+
+    datetime
+    |> Timex.shift(hours: offset_hours)
+    |> DateTime.to_iso8601()
+  end
+
+  defp apply_time_offset(date_str, _), do: date_str
 
   defp from_iso8601(d) do
     {:ok, dt, _} = DateTime.from_iso8601(d.metadata["start"])

--- a/lib/erlef_web/templates/event/show.html.eex
+++ b/lib/erlef_web/templates/event/show.html.eex
@@ -5,11 +5,12 @@
 
           <h1 class="card-title"><%= @event.metadata["title"] %> </h1>
         
-        <% starts = at_date(@event.metadata["start"]) %>
-        <% ends = at_date(@event.metadata["end"]) %>
-        <% offset = @event.metadata["offset"] %> 
+        <% starts = month_name_and_day(@event.metadata["start"]) %>
+        <% ends = month_name_and_day(@event.metadata["end"]) %>
+        <% start_time = time(@event.metadata["start"], @event.metadata["offset"]) %>
+        <% end_time = time(@event.metadata["end"], @event.metadata["offset"]) %>
         
-        <h4 class="d-flex justify-content-center"><span><%= starts %> <%= offset %> - <%= ends %> <%= offset %></span></h4>
+        <h4 class="d-flex justify-content-center"><span><%= starts %> @ <%= start_time %> - <%= ends %> @ <%= end_time %></span></h4>
             <!-- Event header -->
             <div data-title="<%= #{@event.title} %> – Erlang Ecosystem Foundation" data-viewtitle="<%= @event.title %>">
                 <!-- Navigation -->
@@ -44,7 +45,7 @@
                       <dt> Time: </dt>
                       <dd>
                         <div title="<%= year_month_day(@event.metadata["end"]) %>">
-                          <%= time(@event.metadata["start"]) %> <%= @event.metadata["offset"] %>
+                          <%= start_time %>
                         </div>
                       </dd>
                     </dl>
@@ -56,7 +57,7 @@
                       <dt> Time: </dt>
                       <dd>
                         <div title="<%= year_month_day(@event.metadata["end"]) %>">
-                          <%= time(@event.metadata["end"]) %> <%= @event.metadata["offset"] %>
+                          <%= end_time %>
                         </div>
                       </dd>
  

--- a/lib/erlef_web/views/event_view.ex
+++ b/lib/erlef_web/views/event_view.ex
@@ -21,9 +21,26 @@ defmodule ErlefWeb.EventView do
     "#{month} #{day}"
   end
 
-  def time(date_str) do
+  def time(date_str, "UTC" <> offset) when offset != "" do
+    {offset_hours, _offset_minutes_str} = Integer.parse(offset)
+    {:ok, datetime, _offset} = DateTime.from_iso8601(date_str)
+
+    datetime
+    |> Timex.shift(hours: offset_hours)
+    |> format_time
+  end
+
+  def time(date_str, _), do: time(date_str)
+
+  def time(date_str) when is_binary(date_str) do
     {:ok, dt, _offset} = DateTime.from_iso8601(date_str)
-    {:ok, time} = Timex.format(dt, "%T", :strftime)
+    format_time(dt)
+  end
+
+  def time(%DateTime{} = datetime), do: format_time(datetime)
+
+  defp format_time(datetime) do
+    {:ok, time} = Timex.format(datetime, "%T", :strftime)
     time
   end
 end

--- a/priv/events/20190831160632_elixir-conf-jp-2019.md
+++ b/priv/events/20190831160632_elixir-conf-jp-2019.md
@@ -1,8 +1,8 @@
 {
   "title": "ElixirConf Japan",
   "slug": "elixir-conf-jp-2019",
-  "start": "2019-09-07T13:00:00.000000Z",
-  "end": "2019-08-31T20:00:00.000000Z",
+  "start": "2019-09-07T04:00:00.000000Z",
+  "end": "2019-09-07T11:00:00.000000Z",
   "offset": "UTC+09:00",
   "datetime": "2019-08-31T16:06:32.965123Z",
   "gcal_url": "http://www.google.com/calendar/event?action=TEMPLATE&text=%E3%80%90%E5%A4%A7%E4%BA%BA%E6%B0%97%E3%81%AB%E3%81%A4%E3%81%8D%E3%82%A8%E3%83%B3%E3%83%88%E3%83%AA%E3%83%BC%E5%B8%AD%E3%81%AE%E3%81%BF%E5%A2%97%E6%9E%A0%E3%80%91ElixirConfJP%202019%20%E5%B0%8F%E5%80%89%E5%9F%8E&dates=20190907T040000Z/20190907T110000Z&details=https%3A//fukuokaex.connpass.com/event/138846/&location=%E7%A6%8F%E5%B2%A1%E7%9C%8C%E5%8C%97%E4%B9%9D%E5%B7%9E%E5%B8%82%E5%B0%8F%E5%80%89%E5%8C%97%E5%8C%BA%E5%AE%A4%E7%94%BA%EF%BC%91%E4%B8%81%E7%9B%AE%EF%BC%91%E2%88%92%EF%BC%91%E2%88%92%EF%BC%91%EF%BC%91&trp=false&sprop=https%3A//fukuokaex.connpass.com/event/138846/&sprop=name:connpass",

--- a/priv/events/20190901183525_gigcity-elixir-2019.md
+++ b/priv/events/20190901183525_gigcity-elixir-2019.md
@@ -3,7 +3,7 @@
   "slug": "gigcity-elixir-2019",
   "start": "2019-10-17T12:00:00.00Z",
   "end": "2019-10-19T22:00:00.00Z",
-  "offset": "UTC−05:00",
+  "offset": "UTC-05:00",
   "datetime": "2019-08-31 22:13:17.277632Z",
   "event_url": "https://www.gigcityelixir.com/",
   "gcal_url": "https://calendar.google.com/calendar/b/2/r/eventedit?text=GigCity+Elixir+2019&dates=20191017T140000Z/20191019T220000Z&details=For+details,+visit+https://www.gigcityelixir.com/&location=The+Edney+Innovation+Center,+1100+Market+St,+Chattanooga,+TN+37402&sf=true&output=xml&pli=1",


### PR DESCRIPTION
Fix for #44 
display relevant to the area time in event_show template 

I noticed that different times are show in calendar view and in particular event view
so I set the same UTC for calendar, but shift the time of event by time_offset of the area
As a result now it displays the event in calendar view relevant to the area time as well

Minor fixes:
- time of elixir-conf in Japan adjusted to UTC and fixed end day
- fixed ASCII char in offset value for event gigcity-elixir to be able to "parse"