### PR TITLE
Do not assume all posts have a datetime field

### DIFF
--- a/lib/erlef/posts.ex
+++ b/lib/erlef/posts.ex
@@ -3,7 +3,7 @@ defmodule Erlef.Posts do
   alias Erlef.Repo
 
   def all(schema) do
-    schema |> Repo.all() |> sort_by_datetime()
+    schema |> Repo.all()
   end
 
   def get_by_slug(schema, slug) do
@@ -17,7 +17,7 @@ defmodule Erlef.Posts do
     schema |> where([x], x.category == ^cat) |> Repo.all()
   end
 
-  defp sort_by_datetime(posts) do
+  def sort_by_datetime(posts) do
     Enum.sort(
       posts,
       fn p1, p2 ->

--- a/lib/erlef_web/controllers/blog_controller.ex
+++ b/lib/erlef_web/controllers/blog_controller.ex
@@ -46,7 +46,7 @@ defmodule ErlefWeb.BlogController do
 
   defp fetch_working_group(_), do: nil
 
-  def list("eef"), do: Posts.all(Blog)
+  def list("eef"), do: Blog |> Posts.all() |> Posts.sort_by_datetime()
   def list(name) when not is_nil(name), do: Posts.get_by_category(Blog, name)
   def list(_), do: []
 end

--- a/lib/erlef_web/controllers/working_group_controller.ex
+++ b/lib/erlef_web/controllers/working_group_controller.ex
@@ -14,7 +14,6 @@ defmodule ErlefWeb.WorkingGroupController do
   end
 
   def show(conn, %{"id" => slug}) do
-    IO.inspect(slug)
     {:ok, wg} = Posts.get_by_slug(WorkingGroup, slug)
 
     render(conn,


### PR DESCRIPTION
  - remove sort_by_datetime as a private and default filter and make the
  function public which can be used by the caller