### PR TITLE
Provide a meaningful message for non-authed users

### DIFF
--- a/lib/erlef_web/plugs/authz.ex
+++ b/lib/erlef_web/plugs/authz.ex
@@ -11,11 +11,21 @@ defmodule ErlefWeb.Plug.Authz do
     case get_session(conn, :member_session) do
       nil ->
         conn
+        |> Phoenix.Controller.put_flash(:error, error_msg())
         |> Phoenix.Controller.redirect(to: "/")
         |> Plug.Conn.halt()
 
       _ ->
         conn
     end
+  end
+
+  defp error_msg do
+    msg = "The resource you requested requires that you are logged in."
+    link = "https://members.erlef.org/join-us"
+
+    "<h3 class='text-center'>#{msg}</h3><p class='text-center'>Don't have a login? <a href='#{
+      link
+    }'>Join us!</a></p>"
   end
 end


### PR DESCRIPTION
  -  when a user requests a protected resource they should get a useful
  error message