### PR TITLE
Disable bootstrap-select in stipend form

### DIFF
--- a/lib/erlef_web/views/stipend_view.ex
+++ b/lib/erlef_web/views/stipend_view.ex
@@ -318,7 +318,7 @@ defmodule ErlefWeb.StipendView do
 
   def country_select(form) do
     select(form, :country, @country_data,
-      class: "selectpicker form-control",
+      class: "form-control",
       "data-live-search": "true"
     )
   end


### PR DESCRIPTION
 Bootstrap-select was broken in the design update and while having a
 giant select list is undesirable, a non-working form is even more so.

 - closes #186
 - remove selectpicker class from country_select/1 in ErlefWeb.StipendView
 - rename  lib/erlef_web/views/grant_view.ex to lib/erlef_web/views/stipend_view.ex