### PR TITLE
Change mailto for media inquiries

### DIFF
--- a/lib/erlef_web/templates/blog/sidebar.html.eex
+++ b/lib/erlef_web/templates/blog/sidebar.html.eex
@@ -10,10 +10,7 @@
     <h6>Media Inquiries</h6>
     <h4>Journalists and other media professionals</h4>
     <p class="mb-0">
-      For press kits, interviews or publish about us please contact one of the members of our team:
+      For press kits, interviews or publish about us please contact the <a href="mailto:marketing@erlef.org">Marketing Working Group</a>
     </p>
-    <ul class="mt-3">
-      <li>John Doe: <a href="#">email@erlef.org</a></li>
-    </ul>
   </div>
 </aside>


### PR DESCRIPTION
 - Closes #187
 - Update media inquiries section in news side bar to link to
 marketing@erlef.org