### PR TITLE
Adjust opts in Erlef.Storage for public access on event images

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -75,7 +75,7 @@ config :swoosh, preview_port: 4001
 config :erlef, Erlef.Data.Repo,
   database: "erlef_website_dev",
   username: "postgres",
-  password: "postgres", 
+  password: "postgres",
   migration_primary_key: [id: :uuid, type: :binary_id],
   migration_timestamps: [type: :utc_datetime],
   show_sensitive_data_on_connection_error: true,

--- a/lib/erlef/storage.ex
+++ b/lib/erlef/storage.ex
@@ -5,7 +5,7 @@ defmodule Erlef.Storage do
   @spec upload_event_org_image(String.t(), binary(), Keyword.t()) ::
           {:ok, String.t()} | {:error, term()}
   def upload_event_org_image(filename, binary, opts \\ []) do
-    new_opts = [{:content_type, MIME.from_path(filename)}] ++ opts
+    new_opts = [{:content_type, MIME.from_path(filename)}, {:acl, :public_read}] ++ opts
     operation = S3.put_object("event-org-images", filename, binary, new_opts)
 
     case ExAws.request(operation) do


### PR DESCRIPTION
 - Closes #217
 - Objects stored in vultr are private by default, this adds an acl
 option to make objects public by default for event images.