### PR TITLE
Insert active class on event page on click.

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -130,7 +130,7 @@ section {
 }
 
 
-div.blog-post > table { 
+div.blog-post > table {
    width: 100%;
    border-collapse: collapse;
 }
@@ -168,4 +168,15 @@ div.blost-post > th {
         margin-left: calc(-50vw / 2);
         overflow: hidden;
     }
+}
+
+.nav-events {
+  .nav-link {
+    cursor: pointer;
+    color: white;
+
+    .active {
+      color: black;
+    }
+  }
 }

--- a/lib/erlef_web/live/events_live.ex
+++ b/lib/erlef_web/live/events_live.ex
@@ -20,6 +20,7 @@ defmodule ErlefWeb.EventsLive do
   end
 
   def handle_event("filter", %{"filter" => "ALL"}, socket) do
+    socket = assign(socket, :filter, "")
     {:noreply, assign(socket, :events, Query.approved())}
   end
 

--- a/lib/erlef_web/templates/event/_events.html.leex
+++ b/lib/erlef_web/templates/event/_events.html.leex
@@ -1,20 +1,20 @@
 <div class="bg-dark mb-5">
   <div class="container">
-    <ul class="nav bg-dark nav-pills mb-2 py-3 h5 font-weight-normal">
+    <ul class="nav bg-dark nav-pills mb-2 py-3 h5 font-weight-normal nav-events">
       <li class="nav-item">
-        <div class="nav-link active" phx-click="filter" phx-value-filter="ALL" style="cursor: pointer;">All Events</div>
+        <div class="nav-link <%= active_class(@filter, "") %>" phx-click="filter" phx-value-filter="ALL">All Events</div>
       </li>
       <li class="nav-item">
-        <div class="nav-link" phx-click="filter" phx-value-filter="conference" style="cursor: pointer; color: white;">Conferences</div>
+        <div class="nav-link <%= active_class(@filter, "conference") %>" phx-click="filter" phx-value-filter="conference">Conferences</div>
       </li>
       <li class="nav-item">
-        <div class="nav-link" phx-click="filter" phx-value-filter="training" style="cursor: pointer; color: white;">Training</div>
+        <div class="nav-link <%= active_class(@filter, "training") %>" phx-click="filter" phx-value-filter="training">Training</div>
       </li>
       <li class="nav-item">
-        <div class="nav-link" phx-click="filter" phx-value-filter="hackathon" style="cursor: pointer; color: white;">Hackathons</div>
+      <div class="nav-link <%= active_class(@filter, "hackathon") %>" phx-click="filter" phx-value-filter="hackathon">Hackathons</div>
       </li>
       <li class="nav-item">
-        <div class="nav-link" phx-click="filter" phx-value-filter="meetup" style="cursor: pointer; color: white;">Meetups</div>
+        <div class="nav-link <%= active_class(@filter, "meetup") %>" phx-click="filter" phx-value-filter="meetup">Meetups</div>
       </li>
     </ul>
   </div>

--- a/lib/erlef_web/views/event_view.ex
+++ b/lib/erlef_web/views/event_view.ex
@@ -2,4 +2,8 @@ defmodule ErlefWeb.EventView do
   use ErlefWeb, :view
 
   import ErlefWeb.ViewHelpers, only: [event_dates: 2]
+
+  @spec active_class(String.t(), String.t()) :: String.t()
+  def active_class(selected, link_type) when selected == link_type, do: "active"
+  def active_class(_selected, _link_type), do: ""
 end

--- a/test/erlef_web/views/event_view_test.exs
+++ b/test/erlef_web/views/event_view_test.exs
@@ -1,0 +1,15 @@
+defmodule ErlefWeb.EventViewTest do
+  use ExUnit.Case
+
+  alias ErlefWeb.EventView, as: Helper
+
+  describe "active_class/2" do
+    test "returns `active` if the selected and the link type are the same" do
+      assert "active" = Helper.active_class("conference", "conference")
+    end
+
+    test "returns an empty string if the selected is different from the link type" do
+      assert "" = Helper.active_class("conference", "meetup")
+    end
+  end
+end


### PR DESCRIPTION
When on the event page, insert on the clicked element the active class while removing the same class from the other links.

This will fix the issue on the events page where the active class doesn't toggle on the menu.

<details><summary>Before</summary>
<img src="https://user-images.githubusercontent.com/78858/98281488-d5dda800-1f6a-11eb-8956-ca356115054b.gif" />
</details>

<details><summary>After</summary>
<img src="https://user-images.githubusercontent.com/78858/98281507-daa25c00-1f6a-11eb-8fa5-d3c584ef883c.gif" />
</details>

Btw, great website. is getting better and better 👍 