### PR TITLE
Do not allow svg uploads

### DIFF
--- a/lib/erlef/data/schema/event.ex
+++ b/lib/erlef/data/schema/event.ex
@@ -74,8 +74,17 @@ defmodule Erlef.Data.Schema.Event do
     |> cast(params, @all_fields ++ [:approved_by])
   end
 
-  def submission_changeset(struct, params \\ %{}) do
-    struct
+  def submission_changeset(%__MODULE__{} = event, params \\ %{}) do
+    event
+    |> cast(params, @all_fields)
+    |> validate_required(@required_fields)
+    |> unique_constraint(:title)
+    |> maybe_generate_slug()
+    |> post_process_description()
+  end
+
+  def new_submission(params \\ %{}) do
+    %__MODULE__{}
     |> cast(params, @all_fields)
     |> validate_required(@required_fields)
     |> unique_constraint(:title)

--- a/lib/erlef/events.ex
+++ b/lib/erlef/events.ex
@@ -1,12 +1,12 @@
 defmodule Erlef.Events do
   @moduledoc false
 
+  alias Ecto.{Changeset, UUID}
   alias Erlef.Data.Query.Event, as: Query
-  alias Erlef.Data.Schema.Event
+  alias Erlef.Data.Schema.{Event, EventType}
   alias Erlef.Data.Repo
 
-  @spec approve(Ecto.UUID.t(), map()) ::
-          {:ok, Erlef.Data.Schema.Event} | {:error, Ecto.Changeset.t()}
+  @spec approve(UUID.t(), map()) :: {:ok, Event.t()} | {:error, Changeset.t()}
   def approve(id, params) do
     event = Query.get(id)
 
@@ -14,4 +14,66 @@ defmodule Erlef.Events do
     |> Event.approval_changeset(params)
     |> Repo.update()
   end
+
+  @spec event_types() :: [Keyword.t()]
+  def event_types do
+    EventType
+    |> Erlef.Data.Repo.all()
+    |> Enum.map(fn x -> [key: x.name, value: x.id] end)
+  end
+
+  @spec format_error(any()) :: String.t()
+  def format_error({:error, :unsupported_org_file_type}) do
+    "The event organization logo you attempted to upload is not supported." <>
+      " " <>
+      "Supported formats : jpg, png"
+  end
+
+  def format_error(_) do
+    "An unknown error ocurred"
+  end
+
+  @spec new_event() :: Changeset.t()
+  def new_event, do: Event.new_changeset(%Event{}, %{})
+
+  @spec new_event(map()) :: Changeset.t()
+  def new_event(params), do: Event.new_changeset(%Event{}, params)
+
+  @spec submit(params :: map()) :: {:ok, Event.t()} | {:error, Changeset.t()}
+  def submit(params) do
+    with {:ok, event_params} <- maybe_upload_org_image(params),
+         %Changeset{} = cs <- Event.new_submission(event_params),
+         {:ok, cs} <- valid_changeset(cs) do
+      Repo.insert(cs)
+    end
+  end
+
+  defp maybe_upload_org_image(%{"organizer_brand_logo" => %Plug.Upload{} = upload} = params) do
+    with {:ok, organizer_brand_logo} <- File.read(upload.path),
+         {:ok, {ext, mime}} <- org_image_type(organizer_brand_logo),
+         {:ok, url} <- upload_event_org_image(organizer_brand_logo, ext, mime) do
+      {:ok, Map.put(params, "organizer_brand_logo", url)}
+    end
+  end
+
+  defp maybe_upload_org_image(params), do: {:ok, params}
+
+  defp org_image_type(<<0xFF, 0xD8, _::binary>>), do: {:ok, {".jpg", "image/jpeg"}}
+
+  defp org_image_type(<<0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, _::binary>>),
+    do: {:ok, {".png", "image/png"}}
+
+  defp org_image_type(_not_supported), do: {:error, :unsupported_org_file_type}
+
+  defp upload_event_org_image(logo, ext, mime) do
+    uuid = Ecto.UUID.generate()
+    name = "#{uuid}#{ext}"
+    Erlef.Storage.upload_event_org_image(name, logo, content_type: mime)
+  end
+
+  defp valid_changeset(%Changeset{valid?: true} = cs) do
+    {:ok, cs}
+  end
+
+  defp valid_changeset(cs), do: {:error, cs}
 end

--- a/lib/erlef/events.ex
+++ b/lib/erlef/events.ex
@@ -39,7 +39,7 @@ defmodule Erlef.Events do
   @spec new_event(map()) :: Changeset.t()
   def new_event(params), do: Event.new_changeset(%Event{}, params)
 
-  @spec submit(params :: map()) :: {:ok, Event.t()} | {:error, Changeset.t()}
+  @spec submit(params :: map()) :: {:ok, Event.t()} | {:error, term()}
   def submit(params) do
     with {:ok, event_params} <- maybe_upload_org_image(params),
          %Changeset{} = cs <- Event.new_submission(event_params),

--- a/lib/erlef/members.ex
+++ b/lib/erlef/members.ex
@@ -2,25 +2,6 @@ defmodule Erlef.Members do
   @moduledoc """
   Erlef.Members context module
   """
-  alias Erlef.Data.Schema.Event
-  alias Erlef.Data.Repo
-
-  @spec new_event() :: Ecto.Changeset.t()
-  def new_event, do: Event.new_changeset(%Event{}, %{})
-
-  @spec submit_event(params :: map()) :: {:ok, Event.t()} | {:error, Ecto.Changeset.t()}
-  def submit_event(params) do
-    %Ecto.Changeset{} = cs = Event.submission_changeset(%Event{}, params)
-
-    case cs.valid? do
-      true ->
-        Repo.insert(cs)
-
-      false ->
-        {:error, cs}
-    end
-  end
-
   @spec get_display_name(integer()) :: String.t()
   def get_display_name(uid) do
     {:ok, %{"access_token" => token}} = Erlef.WildApricot.get_api_token()

--- a/lib/erlef_web/templates/event_submission/new.html.eex
+++ b/lib/erlef_web/templates/event_submission/new.html.eex
@@ -14,6 +14,12 @@ span.help-block {
       </div>
     <% end %>
 
+    <%= if @error do %>
+      <div class="alert alert-danger">
+        <p><%= @error %></p>
+      </div>
+    <% end %>
+
     <p>
     Fields prefixed with <b>*</b> are required
     </p>
@@ -33,7 +39,6 @@ span.help-block {
         </div>
       </div>
 
-
       <div class="form-group">
         <%= label f, :description, "* Description"%>
         <%= textarea f, :description, class: "form-control", required: true, placeholder: "Full description" %>
@@ -42,7 +47,6 @@ span.help-block {
           Full description about the event. Markdown supported
         </small>
       </div>
-
 
       <div class="form-row">
         <div class="col-md-4 mb-2">
@@ -64,7 +68,6 @@ span.help-block {
         <%= error_tag f, :url %>
       </div>
 
-
       <div class="form-row">
         <div class="col-md-4 mb-2">
           <%= label f, :organizer, "* Organizer" %>
@@ -81,9 +84,10 @@ span.help-block {
 
         <div class="col-md-4 mb-2">
           <%= label f, :organizer_brand_logo, "Organizer Brand Logo" %>
-          <%= file_input f, :organizer_brand_logo, class: "form-control" %>
+          <%= file_input f, :organizer_brand_logo, class: "form-control", accept: ".jpg, .jpeg, .png" %>
           <small class="form-text text-muted">
-            Event Organization logos must be 192x192
+            Event Organization logos must be 192x192. An SVG must be emailed to 
+            <a href="mailto:infra@erlef.org?SUBJECT=Organization Event SVG">infra@erlef.org</a>
           </small>
           <%= error_tag f, :organizer_brand_logo %>
         </div>


### PR DESCRIPTION
  - svg presents a security problem as SVG can be injected with
  javascript and HTML to perform cross site scripting attacks