### PR TITLE
Use strict same site cookie setting

### DIFF
--- a/lib/erlef_web/endpoint.ex
+++ b/lib/erlef_web/endpoint.ex
@@ -5,6 +5,7 @@ defmodule ErlefWeb.Endpoint do
     store: :cookie,
     key: "_erlef_key",
     serializer: Erlef.Session,
+    same_site: "Strict",
     encryption_salt: "41SM3UP3NgSUTzLOqCqF0r2pJBn54JuOy9+cZswJuiQi5pnCIIwJfEYO7DP3/QqR",
     signing_salt: "pSnWMnUh"
   ]


### PR DESCRIPTION
 - Ensure session cookies can not be sent to third parties via utilizing
 the same site cookie setting