### PR TITLE
Fix CSP for websockets

### DIFF
--- a/lib/erlef_web/router.ex
+++ b/lib/erlef_web/router.ex
@@ -24,7 +24,7 @@ defmodule ErlefWeb.Router do
 
     plug :put_secure_browser_headers, %{
       "content-security-policy" =>
-        " default-src 'self' 'unsafe-eval' 'unsafe-inline' data: #{@default_source}"
+        " default-src 'self' 'unsafe-eval' 'unsafe-inline' data: #{@default_source}; connect-src 'self' https://www.erlef.org https://erlef.org wss://erlef.org wss://www.erlef.org ws://erlef.org ws://www.erlef.org"
     }
 
     plug ErlefWeb.Plug.Events


### PR DESCRIPTION
 - In a perfect world all browsers would inherit the connect-src from the default src, sadly this is not a perfect world. Ergo we must explicitly set connect-src to self and all possible valid sources.