### PR TITLE
Add and use twitter-avatar class

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -69,6 +69,10 @@ section {
     background: #444;
 }
 
+.twitter-avatar {
+    overflow: hidden;
+}
+
 .clip-svg {
     -webkit-clip-path: url(#myClip);
             clip-path: url(#myClip);

--- a/lib/erlef_web/templates/layout/twitter_feed.html.eex
+++ b/lib/erlef_web/templates/layout/twitter_feed.html.eex
@@ -4,7 +4,7 @@
     <div class="event-card h-100 rounded bg-white">
       <div class="p-4 d-flex flex-column h-100">
         <div class="d-flex align-items-center mb-3">
-            <div class="avatar rounded-circle mr-2 border"><img class="img-fluid" src="<%= tweet.avatar %>"></div>
+            <div class="twitter-avatar rounded-circle mr-2 border"><img class="img-fluid" src="<%= tweet.avatar %>"></div>
             <div class="font-weight-bold">
                 <%= tweet.name %>
                 <a href="https://twitter.com/<%= tweet.screen_name %>">@<%= tweet.screen_name %></a>
@@ -29,7 +29,7 @@
           <div class="event-card h-100 rounded bg-white">
               <div class="p-4 d-flex flex-column h-100">
                   <div class="d-flex align-items-center mb-3">
-                      <div class="avatar rounded-circle mr-2 border"><img class="img-fluid" src="<%= tweet.avatar %>"></div>
+                      <div class="twitter-avatar rounded-circle mr-2 border"><img class="img-fluid" src="<%= tweet.avatar %>"></div>
                       <div class="font-weight-bold">
                           <%= tweet.name %>
                           <a href="https://twitter.com/<%= tweet.screen_name %>">@<%= tweet.screen_name %></a>


### PR DESCRIPTION
 - the primary avatar class was causing avatars in the twitter feed to
 stretch

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Screenshots

Before : 

<img width="361" alt="Screen Shot 2020-11-26 at 1 20 26 PM" src="https://user-images.githubusercontent.com/39971740/100386124-284e3980-2fea-11eb-868e-630ea51d9922.png">


After : 

<img width="350" alt="Screen Shot 2020-11-26 at 1 20 48 PM" src="https://user-images.githubusercontent.com/39971740/100386145-34d29200-2fea-11eb-9dfc-1a838e14854a.png">

