### PR TITLE
Move from actions/setup-elixir to erlef/setup-elixir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -45,7 +45,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -70,7 +70,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -94,7 +94,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -119,7 +119,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -161,7 +161,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}


### PR DESCRIPTION
 - actions/setup-elixir is set to be archived but the erlef has taken
 over the action, as such we have moved to the new official setup-elixir
 action
