### PR TITLE
Update language for eef slack invite flash message

### DIFF
--- a/lib/erlef_web/controllers/members/slack_invite_controller.ex
+++ b/lib/erlef_web/controllers/members/slack_invite_controller.ex
@@ -36,8 +36,9 @@ defmodule ErlefWeb.Members.SlackInviteController do
 
   defp success_msg do
     """
-    Your slack invite request was successfully created.  
-    An administrator will process your request as soon as possible. 
+    Your slack invite request was successfully created. 
+    Note: There are humans behind this process and as such it can take up 
+    to 24 hours to process an invite. 
     """
   end
 

--- a/lib/erlef_web/controllers/members/slack_invite_controller.ex
+++ b/lib/erlef_web/controllers/members/slack_invite_controller.ex
@@ -36,9 +36,9 @@ defmodule ErlefWeb.Members.SlackInviteController do
 
   defp success_msg do
     """
-    Your slack invite request was successfully created. 
-    Note: There are humans behind this process and as such it can take up 
-    to 24 hours to process an invite. 
+    Your Slack invitation request was successfully created. 
+    Note: there are humans behind this process and as such it can take up 
+    to 24 hours to process it. 
     """
   end
 


### PR DESCRIPTION
 - The intent of this change is set more reasonable expectations around
 how long it could take to process a slack invite for eef slack

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Screenshots

<img width="1437" alt="Screen Shot 2021-03-15 at 7 49 48 PM" src="https://user-images.githubusercontent.com/39971740/111239771-e1e80f00-85c7-11eb-97e3-cd1146572578.png">

