### PR TITLE
Enable same_site strict for Plug.Sesssion

### DIFF
--- a/lib/erlef_web/endpoint.ex
+++ b/lib/erlef_web/endpoint.ex
@@ -7,6 +7,7 @@ defmodule ErlefWeb.Endpoint do
     key: "_erlef_key",
     max_age: 60 * 60 * 24 * 30,
     secure: true,
+    same_site: "strict",
     serializer: Erlef.Session,
     encryption_salt: "41SM3UP3NgSUTzLOqCqF0r2pJBn54JuOy9+cZswJuiQi5pnCIIwJfEYO7DP3/QqR",
     signing_salt: "pSnWMnUh"


### PR DESCRIPTION
- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

This PR merely renables same_site => strict for session cookies. It was disabled per websocket problems but those problems have been resolved.