### PR TITLE
Disable same_strict strict setting

### DIFF
--- a/lib/erlef_web/endpoint.ex
+++ b/lib/erlef_web/endpoint.ex
@@ -7,7 +7,6 @@ defmodule ErlefWeb.Endpoint do
     key: "_erlef_key",
     max_age: 60 * 60 * 24 * 30,
     secure: true,
-    same_site: "strict",
     serializer: Erlef.Session,
     encryption_salt: "41SM3UP3NgSUTzLOqCqF0r2pJBn54JuOy9+cZswJuiQi5pnCIIwJfEYO7DP3/QqR",
     signing_salt: "pSnWMnUh"


### PR DESCRIPTION
 It appears using `same_site: "strict"` prevents oauth login from wildapricot from functioning properly.

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.
