### PR TITLE
Move erlef slack invite notification into special clause on Admins

### DIFF
--- a/lib/erlef/admins.ex
+++ b/lib/erlef/admins.ex
@@ -4,6 +4,22 @@ defmodule Erlef.Admins do
   alias Erlef.Admins.Notifications
   alias Erlef.Mailer
 
+  def notify(:new_slack_invite, %{member: member}) do
+    msg = """
+    A member has requested access to the Erlef slack. 
+
+    Please type `/invite`, hit, then enter the members's email : #{member.email}
+
+    Then click done :tada:
+    """
+
+    if Erlef.is_env?(:prod) do
+      Erlef.SlackInvite.send_to_erlef_slack_invite_channel(msg)
+    else
+      {:ok, :dev_mode}
+    end
+  end
+
   def notify(type, params \\ %{}) do
     type
     |> Notifications.new(params)

--- a/lib/erlef/admins.ex
+++ b/lib/erlef/admins.ex
@@ -4,7 +4,7 @@ defmodule Erlef.Admins do
   alias Erlef.Admins.Notifications
   alias Erlef.Mailer
 
-  def notify(:new_slack_invite, %{member: member}) do
+  def slack_notify(:new_slack_invite, %{member: member}) do
     msg = """
     A member has requested access to the Erlef slack. 
 

--- a/lib/erlef/admins/notifications.ex
+++ b/lib/erlef/admins/notifications.ex
@@ -19,5 +19,4 @@ defmodule Erlef.Admins.Notifications do
     |> subject("A new email request was created")
     |> text_body(msg)
   end
-
 end

--- a/lib/erlef/admins/notifications.ex
+++ b/lib/erlef/admins/notifications.ex
@@ -20,17 +20,4 @@ defmodule Erlef.Admins.Notifications do
     |> text_body(msg)
   end
 
-  def new(:new_slack_invite, %{member: member}) do
-    msg = """
-    A member has requested access to the Erlef slack. 
-
-    Please type `/invite`, hit, then enter the members's email : #{member.email}
-
-    Then click done :tada:
-    """
-
-    if Erlef.is_env?(:prod) do
-      Erlef.SlackInvite.send_to_erlef_slack_invite_channel(msg)
-    end
-  end
 end

--- a/lib/erlef_web/controllers/members/slack_invite_controller.ex
+++ b/lib/erlef_web/controllers/members/slack_invite_controller.ex
@@ -16,7 +16,7 @@ defmodule ErlefWeb.Members.SlackInviteController do
 
   defp process(conn, %Member{has_requested_slack_invite: false} = member) do
     with {:ok, member} <- set_slack_invite_requested(member),
-         {:ok, _} <- Admins.notify(:new_slack_invite, %{member: member}) do
+         {:ok, _} <- Admins.slack_notify(:new_slack_invite, %{member: member}) do
       conn
       |> put_flash(:info, success_msg())
       |> redirect(to: Routes.members_profile_path(conn, :show))


### PR DESCRIPTION
 - since slack invites for eef slack will no longer go to email, move
 the clause from Admins.Notifications into a special clause on Admins

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

