### PR TITLE
Support for multiple authors in blog posts

### DIFF
--- a/lib/erlef/blogs/post.ex
+++ b/lib/erlef/blogs/post.ex
@@ -7,7 +7,7 @@ defmodule Erlef.Blogs.Post do
   import Ecto.Changeset
 
   schema "blogs" do
-    field(:author, :string)
+    field(:authors, {:array, :string})
     field(:title, :string)
     field(:slug, :string)
     field(:category, :string)
@@ -19,21 +19,23 @@ defmodule Erlef.Blogs.Post do
     field(:tags, {:array, :string}, default: [])
   end
 
-  @required_fields [
+  @all_fields [
     :excerpt,
     :excerpt_html,
     :body,
     :body_html,
     :excerpt_html,
-    :author,
+    :authors,
     :slug,
     :category,
     :datetime,
-    :title
+    :title,
+    :tags
   ]
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, @required_fields ++ [:tags])
+    |> cast(params, @all_fields)
+    |> validate_required([:authors, :body, :body_html, :category, :datetime, :tags, :title, :slug])
   end
 end

--- a/lib/erlef_web/templates/blog/index.html.eex
+++ b/lib/erlef_web/templates/blog/index.html.eex
@@ -37,14 +37,13 @@
                   <% month =  Calendar.strftime(post1.datetime, "%B") %>
                   <% day =  post1.datetime.day %>
                   <% year = post1.datetime.year %>
-                  <% _author = post1.author %>
                   <div>
                     <%= month %>
                     <%= day %>,
                     <%= year %>
                   </div>
                   <div>by <a class="text-capitalize" href="#">
-                      <%= post1.author %></a>
+                      <%= author_name(post1.authors) %></a>
                   </div>
                 </div>
               </div>
@@ -82,9 +81,9 @@
               <% month =  Calendar.strftime(post.datetime, "%B") %>
               <% day =  post.datetime.day %>
               <% year = post.datetime.year %>
-              <% author = post.author %>
+              <% author = post.authors %>
               <p class="small">Posted by
-              <%= author %> on
+              <%= author_name(author) %> on
               <%= month %>
               <%= day %>,
               <%= year %>

--- a/lib/erlef_web/templates/layout/news_feed.html.eex
+++ b/lib/erlef_web/templates/layout/news_feed.html.eex
@@ -23,7 +23,7 @@
           </div>
           <div>
             <div><%= long_date(story.datetime) %></div>
-            <div>by <%= author_name(story.author) %></div>
+            <div>by <%= author_name(story.authors) %></div>
           </div>
         </div>
       </div>

--- a/lib/erlef_web/views/blog_view.ex
+++ b/lib/erlef_web/views/blog_view.ex
@@ -17,7 +17,7 @@ defmodule ErlefWeb.BlogView do
     month = Calendar.strftime(post.datetime, "%B")
     day = post.datetime.day
     year = post.datetime.year
-    author = author_name(post.author)
+    author = author_name(post.authors)
 
     "#{month} #{day}, #{year} by #{author}"
   end

--- a/lib/erlef_web/views/view_helpers.ex
+++ b/lib/erlef_web/views/view_helpers.ex
@@ -1,9 +1,11 @@
 defmodule ErlefWeb.ViewHelpers do
   @moduledoc "View Helpers"
 
-  def author_name("eef"), do: "ErlEF"
+  def author_name(["eef"]), do: "ErlEF"
 
-  def author_name(name), do: name
+  def author_name([name]), do: name
+
+  def author_name(names), do: Enum.join(names, ", ")
 
   def blog_tag_name("eef"), do: "announcements"
   def blog_tag_name(name), do: name

--- a/lib/mix/tasks/eef/gen/post.ex
+++ b/lib/mix/tasks/eef/gen/post.ex
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.Eef.Gen.Post do
     case OptionParser.parse(args, switches: switches, aliases: aliases) do
       {options, [blog, slug], _invalid} ->
         title = Keyword.get(options, :title, "Title")
-        author = Keyword.get(options, :author, "Author")
+        author = Keyword.get(options, :authors, "Author")
         datetime = DateTime.utc_now()
         path = Keyword.get(options, :path, root_path(blog))
         file = Path.join(path, "#{format_datetime(datetime)}_#{slug}.md")
@@ -90,7 +90,7 @@ defmodule Mix.Tasks.Eef.Gen.Post do
   embed_template(:post, """
   {
     "title": "<%= @title %>",
-    "author": "<%= @author %>",
+    "authors": ["<%= @author %>"],
     "slug": "<%= @slug %>",
     "category": "<%= @category %>",
     "tags": ["<%= @category %>"],

--- a/priv/posts/education/20210321165506_icfp-erlang-2021-call-for-papers.md
+++ b/priv/posts/education/20210321165506_icfp-erlang-2021-call-for-papers.md
@@ -1,6 +1,6 @@
 {
   "title": "ICFP Erlang 2021 - Call for papers",
-  "author": "Annette Bieniusa",
+  "authors": ["Annette Bieniusa","Stavros Aronis"],
   "slug": "icfp-erlang-2021-call-for-papers",
   "category": "education",
   "tags": ["education", "papers", "icfp"],

--- a/priv/posts/eef/20200227235232_election-2020.md
+++ b/priv/posts/eef/20200227235232_election-2020.md
@@ -1,6 +1,6 @@
 {
   "title": "The EEF Board is Having its First Election",
-  "author": "Fred Hebert",
+  "authors": ["Fred Hebert"],
   "slug": "election-2020",
   "category": "eef",
   "tags": ["eef", "board", "elections"],

--- a/priv/posts/eef/20200401222450_election-2020-results.md
+++ b/priv/posts/eef/20200401222450_election-2020-results.md
@@ -1,6 +1,6 @@
 {
   "title": "The EEF Board 2020 Election is Over",
-  "author": "Fred Hebert",
+  "authors": ["Fred Hebert"],
   "slug": "election-2020-results",
   "category": "eef",
   "tags": ["eef", "board", "elections"],

--- a/priv/posts/eef/20200901030039_agm-2020.md
+++ b/priv/posts/eef/20200901030039_agm-2020.md
@@ -1,6 +1,6 @@
 {
   "title": "EEF 1st. Annual General Meeting",
-  "author": "eef",
+  "authors": ["eef"],
   "slug": "agm-2020",
   "category": "eef",
   "tags": ["eef", "agm"],

--- a/priv/posts/eef/20201217005553_email-for-members.md
+++ b/priv/posts/eef/20201217005553_email-for-members.md
@@ -1,6 +1,6 @@
 {
   "title": "Email for members program",
-  "author": "eef",
+  "authors": ["eef"],
   "slug": "email-for-members",
   "category": "eef",
   "tags": ["eef", "programs"],

--- a/priv/posts/eef/20210225235337_election-2021.md
+++ b/priv/posts/eef/20210225235337_election-2021.md
@@ -1,6 +1,6 @@
 {
   "title": "The EEF Board is Having its 2021 Election",
-  "author": "Fred Hebert",
+  "authors": ["Fred Hebert"],
   "slug": "election-2021",
   "category": "eef",
   "tags": ["eef", "board", "elections"],

--- a/priv/posts/eef/2021032122450_election-2021-results.md
+++ b/priv/posts/eef/2021032122450_election-2021-results.md
@@ -1,6 +1,6 @@
 {
   "title": "The EEF Board 2021 Election is Over",
-  "author": "Fred Hebert",
+  "authors": ["Fred Hebert"],
   "slug": "election-2021-results",
   "category": "eef",
   "tags": ["eef", "board", "elections"],

--- a/priv/posts/fellowship/20190821003333_honoring-our-fellows.md
+++ b/priv/posts/fellowship/20190821003333_honoring-our-fellows.md
@@ -1,6 +1,6 @@
 {
   "title": "Honouring the first Erlang Ecosystem Foundation Fellows,  without whom, there would be no foundation.",
-  "author": "Francesco Cesarini",
+  "authors": ["Francesco Cesarini"],
   "slug": "honoring-our-fellows",
   "category": "fellowship",
   "tags": ["fellowship"],

--- a/priv/posts/fellowship/20200701103144_2020-fellowship-nominations.md
+++ b/priv/posts/fellowship/20200701103144_2020-fellowship-nominations.md
@@ -1,6 +1,6 @@
 {
   "title": "2020 Fellowship Nominations",
-  "author": "Francesco Cesarini",
+  "authors": ["Francesco Cesarini"],
   "slug": "2020-fellowship-nominations",
   "tags": ["eef", "board", "elections"],
   "category": "fellowship",

--- a/priv/posts/newsletter/20190929033313_newsletter-1.md
+++ b/priv/posts/newsletter/20190929033313_newsletter-1.md
@@ -1,6 +1,6 @@
 {
   "title": "EEF Newsletter #1",
-  "author": "EEF",
+  "authors": ["eef"],
   "slug": "newsletter-1",
   "category": "newsletter",
   "datetime": "2019-07-05T03:33:13.411451Z",

--- a/priv/posts/newsletter/20190930005800_newsletter-2.md
+++ b/priv/posts/newsletter/20190930005800_newsletter-2.md
@@ -1,6 +1,6 @@
 {
   "title": "EEF Newsletter #2",
-  "author": "EEF",
+  "authors": ["eef"],
   "slug": "newsletter-2",
   "category": "newsletter",
   "datetime": "2019-08-03T00:58:00.769161Z",

--- a/priv/posts/newsletter/20190930010447_newsletter-3.md
+++ b/priv/posts/newsletter/20190930010447_newsletter-3.md
@@ -1,6 +1,6 @@
 {
   "title": "Introducing Our Stipend Program and New Sponsors",
-  "author": "EEF",
+  "authors": ["eef"],
   "slug": "newsletter-3",
   "category": "newsletter",
   "datetime": "2019-09-06T01:04:47.281151Z",

--- a/priv/posts/newsletter/20191101214942_newsletter-4.md
+++ b/priv/posts/newsletter/20191101214942_newsletter-4.md
@@ -1,6 +1,6 @@
 {
   "title": "New Embedded Working Group, the EEF Joining the OW2 and Other News",
-  "author": "EEF",
+  "authors": ["EEF"],
   "slug": "newsletter-4",
   "category": "newsletter",
   "datetime": "2019-11-01T21:49:42.266975Z",

--- a/priv/posts/newsletter/20210226003648_newsletter-5.md
+++ b/priv/posts/newsletter/20210226003648_newsletter-5.md
@@ -1,6 +1,6 @@
 {
   "title": "EEF Newsletter #5",
-  "author": "eef",
+  "authors": ["eef"],
   "slug": "newsletter-5",
   "category": "newsletter",
   "tags": ["newsletter"],

--- a/priv/posts/wg/20190802222421_time-is-running-out.md
+++ b/priv/posts/wg/20190802222421_time-is-running-out.md
@@ -1,6 +1,6 @@
 {
   "title": "Time is running out!",
-  "author": "EEF",
+  "authors": ["eef"],
   "slug": "time-is-running-out",
   "category": "eef",
   "tags": ["eef"],


### PR DESCRIPTION
  - change "author" to "authors" in front matter and set the standard to
  be a list of strings vs a string, even for posts where there is only
  one author
  - Adjust existing posts per the above
  - Update the eef gen.post task per the above
  - Update view helpers and templates per the above
  - validate required fields in post schema

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

