### PR TITLE
Return a generic error message vs the error in slack invite controller

### DIFF
--- a/lib/erlef_web/controllers/slack_invite_controller.ex
+++ b/lib/erlef_web/controllers/slack_invite_controller.ex
@@ -64,5 +64,5 @@ defmodule ErlefWeb.SlackInviteController do
     "Invalid email Address"
   end
 
-  defp format_error(error), do: error
+  defp format_error(_error), do: "An an unknown error occured while processing your request. Please try again"
 end

--- a/lib/erlef_web/controllers/slack_invite_controller.ex
+++ b/lib/erlef_web/controllers/slack_invite_controller.ex
@@ -64,5 +64,6 @@ defmodule ErlefWeb.SlackInviteController do
     "Invalid email Address"
   end
 
-  defp format_error(_error), do: "An an unknown error occured while processing your request. Please try again"
+  defp format_error(_error),
+    do: "An an unknown error occured while processing your request. Please try again"
 end


### PR DESCRIPTION
 - If a an error occurs (such as a timeout) we need to return a generic
 error message to the user vs the error. The error could be an atom, in
 which case flash messages utilizing raw/1 will fail.

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

