### PR TITLE
Fix typo in generic slack unknown error message

### DIFF
--- a/lib/erlef_web/controllers/slack_invite_controller.ex
+++ b/lib/erlef_web/controllers/slack_invite_controller.ex
@@ -65,5 +65,5 @@ defmodule ErlefWeb.SlackInviteController do
   end
 
   defp format_error(_error),
-    do: "An an unknown error occurred while processing your request. Please try again"
+    do: "An unknown error occurred while processing your request. Please try again"
 end

--- a/lib/erlef_web/controllers/slack_invite_controller.ex
+++ b/lib/erlef_web/controllers/slack_invite_controller.ex
@@ -65,5 +65,5 @@ defmodule ErlefWeb.SlackInviteController do
   end
 
   defp format_error(_error),
-    do: "An an unknown error occured while processing your request. Please try again"
+    do: "An an unknown error occurred while processing your request. Please try again"
 end


### PR DESCRIPTION
- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.
