### PR TITLE
Switch to new name setup-beam for setting up elixir

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -45,7 +45,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -70,7 +70,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -94,7 +94,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -119,7 +119,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}
@@ -161,7 +161,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: setup
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ env.otp-version }}
           elixir-version: ${{ env.elixir-version }}


### PR DESCRIPTION
 - setup-elixir was renamed to setup-beam

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

