### PR TITLE
Put Events link back in main header

### DIFF
--- a/lib/erlef_web/templates/layout/header.html.eex
+++ b/lib/erlef_web/templates/layout/header.html.eex
@@ -20,7 +20,7 @@
         <li class="nav-item"><a href="/wg/" class="nav-link">Working Groups</a></li>
         <li class="nav-item"><a href="/stipends/" class="nav-link">Stipends</a></li>
         <li class="nav-item"><a href="/news/" class="nav-link">News</a></li>
-
+        <li class="nav-item"><a href="/events/" class="nav-link">Events</a>
        <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="resources-dropdown" 
                 role="button" data-toggle="dropdown" aria-haspopup="true"
@@ -28,7 +28,6 @@
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="resources-dropdown">
             <a class="dropdown-item" href="/academic-papers/">Academic Papers</a>
             <a class="dropdown-item" href="/community/">Community</a>
-            <a class="dropdown-item" href="/events/">Events</a>
           </div>
         </li>
         


### PR DESCRIPTION
 - We moved events to the resources drop down, but this is perhaps hard
 to find. Thus, this commit puts events back in the header as a main
 link.

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Screenshots

Before 👇 
<img width="1438" alt="Screen Shot 2021-03-30 at 1 25 50 PM" src="https://user-images.githubusercontent.com/39971740/113037863-740d1d00-915b-11eb-9d59-520b71df9ee0.png">


After 👇 

<img width="1437" alt="Screen Shot 2021-03-30 at 1 26 26 PM" src="https://user-images.githubusercontent.com/39971740/113037951-89824700-915b-11eb-88a0-d6fc2701124a.png">
