### PR TITLE
Adjust Community.submit_event/1 to send out a notification to admins

### DIFF
--- a/lib/erlef/admins/notifications.ex
+++ b/lib/erlef/admins/notifications.ex
@@ -19,4 +19,17 @@ defmodule Erlef.Admins.Notifications do
     |> subject("A new email request was created")
     |> text_body(msg)
   end
+
+  @spec new(notification_type(), params()) :: Swoosh.Email.t()
+  def new(:new_event_submitted, _) do
+    msg = """
+    A new event was submitted. Visit https://erlef.org/admin/ to view unapproved events.
+    """
+
+    new()
+    |> to({"Infrastructure Requests", "infra@erlef.org"})
+    |> from({"Erlef Notifications", "notifications@erlef.org"})
+    |> subject("A new event was submitted")
+    |> text_body(msg)
+  end
 end

--- a/lib/erlef/community.ex
+++ b/lib/erlef/community.ex
@@ -6,7 +6,7 @@ defmodule Erlef.Community do
   alias Ecto.{Changeset, UUID}
   alias Erlef.Community.Query
   alias Erlef.Community.Event
-  alias Erlef.Repo
+  alias Erlef.{Admins, Repo}
   alias Erlef.Community.Resources
 
   defdelegate approved_events(), to: Query
@@ -55,8 +55,10 @@ defmodule Erlef.Community do
   def submit_event(params) do
     with {:ok, event_params} <- maybe_upload_org_image(params),
          %Changeset{} = cs <- Event.new_submission(event_params),
-         {:ok, cs} <- valid_changeset(cs) do
-      Repo.insert(cs)
+         {:ok, cs} <- valid_changeset(cs), 
+         {:ok, event} <- Repo.insert(cs),
+         {:ok, _notify} <- Admins.notify(:new_event_submitted) do 
+          {:ok, event}
     end
   end
 

--- a/test/erlef/community_test.exs
+++ b/test/erlef/community_test.exs
@@ -3,6 +3,7 @@ defmodule Erlef.CommunityTest do
 
   alias Erlef.Community
   alias Erlef.Community.Event
+  import Swoosh.TestAssertions
 
   test "event_types/0" do
     assert [:conference, :training, :meetup, :hackathon] = Community.event_types()
@@ -17,6 +18,7 @@ defmodule Erlef.CommunityTest do
     p = string_params_for(:event, type: :hackathon)
     p = Map.put(p, "organizer_brand_logo", logo)
     assert {:ok, %Event{}} = Community.submit_event(p)
+    assert_email_sent(Erlef.Admins.Notifications.new(:new_event_submitted, %{}))
   end
 
   test "approve/2" do


### PR DESCRIPTION
- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

Closes #303 