### PR TITLE
Send receipt on submission and approval of event to member

### DIFF
--- a/lib/erlef/members.ex
+++ b/lib/erlef/members.ex
@@ -15,7 +15,7 @@ defmodule Erlef.Members do
     EmailRequest.changeset(%EmailRequest{}, params)
   end
 
-  def notify(type, params \\ %{}) do
+  def notify(type, params) do
     type
     |> Notifications.new(params)
     |> Mailer.deliver()

--- a/lib/erlef/members.ex
+++ b/lib/erlef/members.ex
@@ -4,8 +4,7 @@ defmodule Erlef.Members do
   """
 
   alias Erlef.Repo
-  alias Erlef.Members.EmailRequest
-  alias Erlef.Members.EmailRequestNotification
+  alias Erlef.Members.{EmailRequest, EmailRequestNotification, Notifications}
   alias Erlef.Mailer
   alias Erlef.Admins
   alias Erlef.Accounts.Member
@@ -14,6 +13,12 @@ defmodule Erlef.Members do
 
   def new_email_request(params \\ %{}) do
     EmailRequest.changeset(%EmailRequest{}, params)
+  end
+
+  def notify(type, params \\ %{}) do
+    type
+    |> Notifications.new(params)
+    |> Mailer.deliver()
   end
 
   def create_email_request(params) do
@@ -65,7 +70,7 @@ defmodule Erlef.Members do
     with %EmailRequest{} = req <- get_email_request(id),
          {:ok, member} <- update_member_fields(req),
          {:ok, _req} <- update_email_request(req.id, %{status: :completed}) do
-      notify(req, %{member: member, password: password})
+      do_notify(req, %{member: member, password: password})
     end
   end
 
@@ -73,7 +78,7 @@ defmodule Erlef.Members do
     with %EmailRequest{} = req <- get_email_request(id),
          {:ok, member} <- update_member_fields(req),
          {:ok, req} <- update_email_request(req.id, %{status: :completed}) do
-      notify(req, %{member: member})
+      do_notify(req, %{member: member})
     end
   end
 
@@ -117,7 +122,7 @@ defmodule Erlef.Members do
     end
   end
 
-  defp notify(%EmailRequest{type: :email_alias}, params) do
+  def do_notify(%EmailRequest{type: :email_alias}, params) do
     {:ok, _} =
       params.member
       |> EmailRequestNotification.email_alias_created()
@@ -126,7 +131,7 @@ defmodule Erlef.Members do
     :ok
   end
 
-  defp notify(%EmailRequest{type: :email_box}, params) do
+  def do_notify(%EmailRequest{type: :email_box}, params) do
     {:ok, _} =
       params.member
       |> EmailRequestNotification.email_box_created(params.password)

--- a/lib/erlef/members/notifications.ex
+++ b/lib/erlef/members/notifications.ex
@@ -7,6 +7,8 @@ defmodule Erlef.Members.Notifications do
 
   @type params() :: map()
 
+  def new(type, params \\ %{})
+
   def new(:new_event_submitted, %{member: member}) do
     msg = """
     Thanks for submitting a new event, we appreciate your involvment in our community. 

--- a/lib/erlef/members/notifications.ex
+++ b/lib/erlef/members/notifications.ex
@@ -1,0 +1,47 @@
+defmodule Erlef.Members.Notifications do
+  @moduledoc false
+
+  import Swoosh.Email
+
+  @type notification_type() :: :new_event_submitted | :new_event_approved
+
+  @type params() :: map()
+
+  def new(:new_event_submitted, %{member: member}) do
+    msg = """
+    Thanks for submitting a new event, we appreciate your involvment in our community. 
+    An admin will approve the event for display shortly. Once approved you will get an email stating so. 
+
+    In the event you haven't seen an approval in 48 hours please send an email to web_admin@erlef.org.
+
+    Thanks
+
+    The Erlang Ecosystem Foundation
+    """
+
+    new()
+    |> to({member.name, member.email})
+    |> from({"Erlef Notifications", "notifications@erlef.org"})
+    |> subject("You submitted a new event")
+    |> text_body(msg)
+  end
+
+  def new(:new_event_approved, %{member: member}) do
+    msg = """
+    An event you submitted has been approved and is now published on the site.
+
+    Once again, we appreciate your involvement with our community and hope to see more event submissions
+    from you in the future! 
+
+    Thanks
+
+    The Erlang Ecosystem Foundation
+    """
+
+    new()
+    |> to({member.name, member.email})
+    |> from({member.name, member.email})
+    |> subject("Your submitted event has been approved!")
+    |> text_body(msg)
+  end
+end

--- a/lib/erlef/members/notifications.ex
+++ b/lib/erlef/members/notifications.ex
@@ -7,8 +7,6 @@ defmodule Erlef.Members.Notifications do
 
   @type params() :: map()
 
-  def new(type, params \\ %{})
-
   def new(:new_event_submitted, %{member: member}) do
     msg = """
     Thanks for submitting a new event, we appreciate your involvment in our community. 

--- a/lib/erlef_web/controllers/event_submission_controller.ex
+++ b/lib/erlef_web/controllers/event_submission_controller.ex
@@ -9,7 +9,7 @@ defmodule ErlefWeb.EventSubmissionController do
 
     p = Map.put(params, "submitted_by_id", user.id)
 
-    case Community.submit_event(p) do
+    case Community.submit_event(p, %{member: user}) do
       {:ok, _event} ->
         conn
         |> put_flash(

--- a/test/erlef/community_test.exs
+++ b/test/erlef/community_test.exs
@@ -18,8 +18,9 @@ defmodule Erlef.CommunityTest do
     p = string_params_for(:event, type: :hackathon)
     member = insert_member!("basic_member")
     p = Map.merge(p, %{"organizer_brand_logo" => logo, "submitted_by_id" => member.id})
-    assert {:ok, %Event{}} = Community.submit_event(p)
+    assert {:ok, %Event{}} = Community.submit_event(p, %{member: member})
     assert_email_sent(Erlef.Admins.Notifications.new(:new_event_submitted, %{}))
+    assert_email_sent(Erlef.Members.Notifications.new(:new_event_submitted, %{member: member}))
   end
 
   test "approve/2" do
@@ -43,6 +44,7 @@ defmodule Erlef.CommunityTest do
     assert Community.unapproved_events_count() == 0
     assert [] = Community.unapproved_events()
     assert [%Event{}] = Community.approved_events()
+    assert_email_sent(Erlef.Members.Notifications.new(:new_event_approved, %{member: member}))
   end
 
   test "get_event/1" do


### PR DESCRIPTION
 Per this commit when an an event is submitted and when the event is
 approved, an email will be sent to the member whom submitted the event
 as a receipt.

 - Added Erlef.Members.Notifications ala Admins.Notifications
 - Added a new notify/2 public function on members and renamed existing
 private function to `do_notify`
 - Changed Community.submit_event/1 to Community.submit_event/2 which
 now takes an options map, namely used for notification purposes
 - Modified the bodies of both Community.submit_event/2 and Community.approve_event/1
 to be executed inside a transaction.
