### PR TITLE
Constrain members on member_email_requests

### DIFF
--- a/lib/erlef/members.ex
+++ b/lib/erlef/members.ex
@@ -37,17 +37,17 @@ defmodule Erlef.Members do
     end
   end
 
-  def get_email_request(id), do: Repo.get(EmailRequest, id)
+  def get_email_request(id), do: Repo.one(EmailRequest.get(id))
 
   def has_email_request?(member) do
-    case Repo.get_by(EmailRequest, submitted_by: member.id) do
+    case Repo.get_by(EmailRequest, submitted_by_id: member.id) do
       nil -> false
       _ -> true
     end
   end
 
   def get_email_request_by_member(member) do
-    Repo.get_by(EmailRequest, submitted_by: member.id)
+    Repo.get_by(EmailRequest, submitted_by_id: member.id)
   end
 
   def update_email_request(%EmailRequest{} = req, params) do
@@ -113,7 +113,7 @@ defmodule Erlef.Members do
           %{erlef_email_address: email, has_email_box?: false, has_email_alias?: true}
       end
 
-    case Erlef.Accounts.get_member!(req.submitted_by) do
+    case Erlef.Accounts.get_member!(req.submitted_by_id) do
       %Member{} = member ->
         Erlef.Accounts.update_member(member, update, update_external: true)
 

--- a/lib/erlef_web/controllers/admin/email_requests_controller.ex
+++ b/lib/erlef_web/controllers/admin/email_requests_controller.ex
@@ -16,8 +16,6 @@ defmodule ErlefWeb.Admin.EmailRequestController do
         cast_assigned_to(l, conn)
       end)
 
-    eh = %{req | logs: logs}
-
     render(conn,
       email_request: %{req | logs: logs}
     )

--- a/lib/erlef_web/controllers/admin/email_requests_controller.ex
+++ b/lib/erlef_web/controllers/admin/email_requests_controller.ex
@@ -10,17 +10,16 @@ defmodule ErlefWeb.Admin.EmailRequestController do
 
   def show(conn, %{"id" => id}) do
     req = Members.get_email_request(id)
-    member = Erlef.Accounts.get_member!(req.submitted_by)
-
-    req = cast_assigned_to(req, conn)
 
     logs =
       Enum.map(req.logs, fn l ->
         cast_assigned_to(l, conn)
       end)
 
+    eh = %{req | logs: logs}
+
     render(conn,
-      email_request: %{req | logs: logs, submitted_by: member}
+      email_request: %{req | logs: logs}
     )
   end
 
@@ -30,7 +29,7 @@ defmodule ErlefWeb.Admin.EmailRequestController do
     {:ok, _req} =
       Members.update_email_request(req, %{
         status: :in_progress,
-        assigned_to: conn.assigns.current_user.id
+        assigned_to_id: conn.assigns.current_user.id
       })
 
     redirect(conn, to: Routes.admin_email_request_path(conn, :show, id))
@@ -47,7 +46,7 @@ defmodule ErlefWeb.Admin.EmailRequestController do
   end
 
   defp cast_assigned_to(req, conn) do
-    case req.assigned_to do
+    case req.assigned_to_id do
       nil ->
         req
 

--- a/lib/erlef_web/controllers/members/email_request_controller.ex
+++ b/lib/erlef_web/controllers/members/email_request_controller.ex
@@ -18,7 +18,7 @@ defmodule ErlefWeb.Members.EmailRequestController do
   def create(conn, %{"email_request" => params}) do
     req_params = %{
       "status" => "created",
-      "submitted_by" => conn.assigns.current_user.id
+      "submitted_by_id" => conn.assigns.current_user.id
     }
 
     case Members.create_email_request(Map.merge(params, req_params)) do

--- a/priv/repo/migrations/20210406000315_add_submitted_by_id_on_email_requests.exs
+++ b/priv/repo/migrations/20210406000315_add_submitted_by_id_on_email_requests.exs
@@ -1,0 +1,16 @@
+defmodule Erlef.Repo.Migrations.AddSubmittedByIdOnEmailRequests do
+  use Ecto.Migration
+
+  def change do
+    alter table(:member_email_requests) do 
+      modify :assigned_to, :uuid, null: true
+      modify :submitted_by, :uuid, null: true
+      add :assigned_to_id, references(:members), null: true
+      add :submitted_by_id, references(:members), null: true
+    end
+
+   execute("update member_email_requests set assigned_to_id = submitted_by")
+   execute("update member_email_requests set submitted_by_id = submitted_by")
+
+  end
+end

--- a/test/erlef/members/email_request_test.exs
+++ b/test/erlef/members/email_request_test.exs
@@ -5,7 +5,7 @@ defmodule Erlef.Members.EmailRequestTest do
 
   describe "changeset/2" do
     test "when username is valid" do
-      p = %{status: :created, type: :email_alias, submitted_by: Ecto.UUID.generate()}
+      p = %{status: :created, type: :email_alias, submitted_by_id: Ecto.UUID.generate()}
       cs = EmailRequest.changeset(%EmailRequest{}, Map.put(p, :username, "foo.bar"))
       assert cs.valid?
       cs = EmailRequest.changeset(%EmailRequest{}, Map.put(p, :username, "f_o_o.b_a_r"))
@@ -16,7 +16,7 @@ defmodule Erlef.Members.EmailRequestTest do
     end
 
     test "when username is invalid" do
-      p = %{status: :created, type: :email_alias, submitted_by: Ecto.UUID.generate()}
+      p = %{status: :created, type: :email_alias, submitted_by_id: Ecto.UUID.generate()}
       cs = EmailRequest.changeset(%EmailRequest{}, Map.put(p, :username, "foo.bar!"))
       refute cs.valid?
       cs = EmailRequest.changeset(%EmailRequest{}, Map.put(p, :username, "f_o_o.b_a_r@"))

--- a/test/erlef/members_test.exs
+++ b/test/erlef/members_test.exs
@@ -26,11 +26,11 @@ defmodule Erlef.MembersTest do
                status: :created,
                type: :email_alias,
                username: "starbelly",
-               submitted_by: member.id
+               submitted_by_id: member.id
              })
 
-    assert ^req = Members.get_email_request(req.id)
-    assert ^req = Members.get_email_request_by_member(member)
+    assert %EmailRequest{id: id} = Members.get_email_request(req.id)
+    assert %EmailRequest{id: ^id} = Members.get_email_request_by_member(member)
     assert_email_sent(Erlef.Admins.Notifications.new(:new_email_request, %{}))
   end
 
@@ -40,7 +40,7 @@ defmodule Erlef.MembersTest do
                status: :created,
                type: :email_alias,
                username: "starbelly",
-               submitted_by: member.id
+               submitted_by_id: member.id
              })
 
     assert Members.has_email_request?(member)
@@ -57,7 +57,7 @@ defmodule Erlef.MembersTest do
                status: :created,
                type: :email_alias,
                username: "starbelly",
-               submitted_by: member.id
+               submitted_by_id: member.id
              })
 
     assert Members.update_email_request(req, %{status: :in_progress})
@@ -66,28 +66,28 @@ defmodule Erlef.MembersTest do
   end
 
   describe "complete_email_request/1" do
-    test "when request is of type email_alias", %{member: member} do
+    test "when request is of type email_alias", %{admin: admin, member: member} do
       assert {:ok, %EmailRequest{} = req} =
                Members.create_email_request(%{
                  status: :created,
                  type: :email_alias,
                  username: "starbelly",
-                 assigned_to: Ecto.UUID.generate(),
-                 submitted_by: member.id
+                 assigned_to_id: admin.id,
+                 submitted_by_id: member.id
                })
 
       assert Members.complete_email_request(%{id: req.id})
       assert_email_sent(Members.EmailRequestNotification.email_alias_created(member))
     end
 
-    test "when request is of type email_box", %{member: member} do
+    test "when request is of type email_box", %{admin: admin, member: member} do
       assert {:ok, %EmailRequest{} = req} =
                Members.create_email_request(%{
                  status: :created,
                  type: :email_box,
                  username: "starbelly",
-                 assigned_to: Ecto.UUID.generate(),
-                 submitted_by: member.id
+                 assigned_to_id: admin.id,
+                 submitted_by_id: member.id
                })
 
       member = Accounts.get_member!(member.id)


### PR DESCRIPTION
 - add a migration which adds FKs to members on member_email_requests to
 members for submitted_by and assigned_to
 - Update related to code to use submitted_by_id and assigned_to_id

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.
