### PR TITLE
Update event card image wrapper width

### DIFF
--- a/assets/css/events.scss
+++ b/assets/css/events.scss
@@ -4,7 +4,7 @@
 }
 
 .event-card-image-wrapper {
-    width: 8rem;
+    width: 10rem;
 
     flex-shrink: 0;
 }


### PR DESCRIPTION
- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Screenshots

## Before

<img width="703" alt="Screen Shot 2021-05-29 at 11 00 47 AM" src="https://user-images.githubusercontent.com/39971740/120076818-20d91d00-c06d-11eb-97ba-4a35399fe4d7.png">


## After

<img width="671" alt="Screen Shot 2021-05-29 at 11 01 35 AM" src="https://user-images.githubusercontent.com/39971740/120076844-3e0deb80-c06d-11eb-8c6c-7093ae4e3f7a.png">

