### PR TITLE
Show current working group chairs

### DIFF
--- a/lib/erlef_web/templates/working_group/show.html.eex
+++ b/lib/erlef_web/templates/working_group/show.html.eex
@@ -13,5 +13,5 @@
       </ul>
 
       <div class="mt-5">
-        <%= render "gallery.html", Map.put(assigns, :members, Enum.shuffle(@wg.volunteers)) %>
+        <%= render_shared "gallery.html", Map.put(assigns, :members, Enum.shuffle(@wg.volunteers)) %>
       </div>

--- a/lib/erlef_web/templates/working_group/show.html.eex
+++ b/lib/erlef_web/templates/working_group/show.html.eex
@@ -2,7 +2,16 @@
     <p class="lead">
       <%= @wg.description %>
     </p>
-      <%= raw @wg.charter_html %>
+    <%= raw @wg.charter_html %>
+    <h4>Current Working Group Chairs</h4>
+      <ul>
+        <%= for %{name: name} = member <- @wg.volunteers do %> 
+          <%= if Erlef.Groups.is_chair?(@wg, member) do %>
+            <li><%= name %></li>
+          <% end %>
+        <% end %>
+      </ul>
+
       <div class="mt-5">
-        <%= render_shared "gallery.html", Map.put(assigns, :members, Enum.shuffle(@wg.volunteers)) %>
+        <%= render "gallery.html", Map.put(assigns, :members, Enum.shuffle(@wg.volunteers)) %>
       </div>


### PR DESCRIPTION
This commit adjusts the show page for working groups to show the current working groups chairs. Note that currently there is nothing to distinguish a chair from a co-chair (we don't have that concept _yet_). 

A ribbon on images might be a better way to do this, but this works for now. 

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Screenshots

<img width="838" alt="Screen Shot 2021-07-06 at 5 27 29 PM" src="https://user-images.githubusercontent.com/39971740/124682539-a16f1280-de90-11eb-9b1c-86c32cd66989.png">

