### PR TITLE
Notifications should always come from notifications@erlef.org

### DIFF
--- a/lib/erlef/members/notifications.ex
+++ b/lib/erlef/members/notifications.ex
@@ -40,7 +40,7 @@ defmodule Erlef.Members.Notifications do
 
     new()
     |> to({member.name, member.email})
-    |> from({member.name, member.email})
+    |> from({"Erlef Notifications", "notifications@erlef.org"})
     |> subject("Your submitted event has been approved!")
     |> text_body(msg)
   end


### PR DESCRIPTION
 Fixed bug whereby we were trying to send an email to the user from
themselves (i.e., send to foo@bar.org from foo@bar.org) when an event was approved.

The bug was silent if the submitter of an event happened to be logged in and have a @erlef.org account associated with
their account.

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.
