### PR TITLE
Handle the case when ics description folding is broken

### DIFF
--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -75,7 +75,10 @@ document.addEventListener('DOMContentLoaded', function() {
                         let xhr = new XMLHttpRequest();
                         xhr.open('GET', ics_url, true);   
                         xhr.onload = function () {
-                            let iCalFeed = ICAL.parse(xhr.responseText);
+                            // We perform a regex on the response text as line folding can get
+                            // borked at least when the new line is not followed by a space and the
+                            // new line begins with escaped chars.
+                            let iCalFeed = ICAL.parse(xhr.responseText.replace(/\n^\\/mg, "\n \\"));
                             let iCalComponent = new ICAL.Component(iCalFeed);
                             let vtimezones = iCalComponent.getAllSubcomponents("vtimezone");
                             vtimezones.forEach(function (vtimezone) {


### PR DESCRIPTION
When we pull in ics files via xhr in calendar.js line folding
for long descriptions get managled. Specifically, rfc 2445 states
that lines that fold on a description line must be preceeded with a space.

This commit handles a very specific case when the there is no space on folded lines
that begins with an escape (e.g, \\,).

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

