### PR TITLE
Fix parsing on backend for combined calendars

### DIFF
--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -86,7 +86,6 @@ document.addEventListener('DOMContentLoaded', function() {
                             });
 
                             let ical_events = iCalComponent.getAllSubcomponents('vevent');
-                            console.log(ical_events.flatMap(build_event).flat());
                             successCallback(ical_events.flatMap(build_event).flat()); 
                         }
                         xhr.send();

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -75,10 +75,6 @@ document.addEventListener('DOMContentLoaded', function() {
                         let xhr = new XMLHttpRequest();
                         xhr.open('GET', ics_url, true);   
                         xhr.onload = function () {
-                            // We perform a regex on the response text as line folding can get
-                            // borked at least when the new line is not followed by a space and the
-                            // new line begins with escaped chars.
-                            console.log(xhr.responseText);
                             let iCalFeed = ICAL.parse(xhr.responseText);
                             let iCalComponent = new ICAL.Component(iCalFeed);
                             let vtimezones = iCalComponent.getAllSubcomponents("vtimezone");

--- a/assets/js/calendar.js
+++ b/assets/js/calendar.js
@@ -22,8 +22,8 @@ function build_event(vevent) {
 
     let recurrances = [];
     let i = 0;
-    for (i = 0; i < 12; i++) {
-        if (i === 12) { break; }
+    for (i = 0; i < 52; i++) {
+        if (i === 52) { break; }
         let next = iterator.next();
         if (event && next) { 
             let occurance = event.getOccurrenceDetails(next);
@@ -78,7 +78,8 @@ document.addEventListener('DOMContentLoaded', function() {
                             // We perform a regex on the response text as line folding can get
                             // borked at least when the new line is not followed by a space and the
                             // new line begins with escaped chars.
-                            let iCalFeed = ICAL.parse(xhr.responseText.replace(/\n^\\/mg, "\n \\"));
+                            console.log(xhr.responseText);
+                            let iCalFeed = ICAL.parse(xhr.responseText);
                             let iCalComponent = new ICAL.Component(iCalFeed);
                             let vtimezones = iCalComponent.getAllSubcomponents("vtimezone");
                             vtimezones.forEach(function (vtimezone) {
@@ -89,6 +90,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             });
 
                             let ical_events = iCalComponent.getAllSubcomponents('vevent');
+                            console.log(ical_events.flatMap(build_event).flat());
                             successCallback(ical_events.flatMap(build_event).flat()); 
                         }
                         xhr.send();

--- a/lib/erlef/agenda/parser.ex
+++ b/lib/erlef/agenda/parser.ex
@@ -20,7 +20,7 @@ defmodule Erlef.Agenda.Parser do
     |> wrap(opts)
   end
 
-  defp split_and_trim(ics_str) do 
+  defp split_and_trim(ics_str) do
     Enum.map(String.split(ics_str, "\n"), fn s -> s end)
   end
 

--- a/lib/erlef/agenda/parser.ex
+++ b/lib/erlef/agenda/parser.ex
@@ -20,8 +20,9 @@ defmodule Erlef.Agenda.Parser do
     |> wrap(opts)
   end
 
-  defp split_and_trim(ics_str),
-    do: Enum.map(String.split(ics_str, "\n"), fn s -> String.trim(s) end)
+  defp split_and_trim(ics_str) do 
+    Enum.map(String.split(ics_str, "\n"), fn s -> s end)
+  end
 
   defp wrap(body, opts) do
     name = Keyword.get(opts, :name, "Erlef Calendar")
@@ -42,23 +43,23 @@ defmodule Erlef.Agenda.Parser do
 
   defp get_events_and_timezones([], acc), do: acc
 
-  defp get_events_and_timezones([<<"BEGIN:VTIMEZONE">> = line | lines], acc) do
+  defp get_events_and_timezones([<<"BEGIN:VTIMEZONE\r">> = line | lines], acc) do
     {lines, timezone} = collect_timezone(lines, [line])
     get_events_and_timezones(lines, [timezone | acc])
   end
 
-  defp get_events_and_timezones([<<"BEGIN:VEVENT">> = line | lines], acc) do
+  defp get_events_and_timezones([<<"BEGIN:VEVENT\r">> = line | lines], acc) do
     {lines, event} = collect_event(lines, [line])
     get_events_and_timezones(lines, [event | acc])
   end
 
   defp get_events_and_timezones([_ | lines], acc), do: get_events_and_timezones(lines, acc)
 
-  defp collect_event([<<"END:VEVENT">> = line | lines], acc), do: {lines, [line | acc]}
+  defp collect_event([<<"END:VEVENT\r">> = line | lines], acc), do: {lines, [line | acc]}
 
   defp collect_event([line | lines], acc), do: collect_event(lines, [line | acc])
 
-  defp collect_timezone([<<"END:VTIMEZONE">> = line | lines], acc), do: {lines, [line | acc]}
+  defp collect_timezone([<<"END:VTIMEZONE\r">> = line | lines], acc), do: {lines, [line | acc]}
 
   defp collect_timezone([line | lines], acc), do: collect_timezone(lines, [line | acc])
 end


### PR DESCRIPTION
The previous commit added a fixup via a regex to deal with an edge case. Said edge case
was actually caused by the backend not properly parsing ics files when combining public calendars per RFC 2445.

Specifically, we were trimming which caused spaces required for line folding. This resulted
in parse errors from ical.js.

In addition, we were grabbing 12 recurring events vs 52 (52 weeks in a year) and so
some events stopped showing up.

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Screenshots

Please attach screenshots and/or gifs of any visible changes to pages here.
