### PR TITLE
Adjust time for agm-2021 post

### DIFF
--- a/priv/posts/eef/20210902233320_agm-2021.md
+++ b/priv/posts/eef/20210902233320_agm-2021.md
@@ -15,10 +15,8 @@ how it's doing, and to ask questions you might have to the board.
 
 ## Zoom Conference Call Times
 
-Thursday Sept 9th, 20:00 CET / 18:00 UTC / 09:00 USA Pacific Time
-
 **Meeting A:** EEF Annual General Meeting 2021 EMEA / Americas
-Time: Thursday, Sep 9th, 2021 20:00 CET / 18:00 UTC / 09:00 USA Pacific Time 
+Time: Thursday, Sep 9th, 2021 20:00 CET / 18:00 UTC / 11:00 USA Pacific Time 
 
 Members will receive an email with a link and credentials for the meetings. 
 


### PR DESCRIPTION
Correct pacific time is 11:00am PST vs 9:00am

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.