### PR TITLE
Add missing sub-section to ninefx meet-the-sponsors post

### DIFF
--- a/priv/posts/sponsorship/20211118011248_meet-the-sponsors-ninefx.md
+++ b/priv/posts/sponsorship/20211118011248_meet-the-sponsors-ninefx.md
@@ -31,6 +31,8 @@ Moreover, they are an active part of the Security working group, so they plan to
 
 They would like to see the foundation sponsor work on development projects that benefit the community as a whole.
 
+# A little more about NineFX
+
 The company was founded in 2009 and is based in Columbia, South Carolina, and most of its employees work there.
 
 


### PR DESCRIPTION
- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.


