### PR TITLE
Fix cannot mix test in local dev

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-elixir 1.11.2
-erlang 23.1.2
+elixir 1.13.3
+erlang 24.2.2
 nodejs 12.6.0
 yarn 1.16.0


### PR DESCRIPTION
$ mix test
** (Mix) You're trying to run :erlef on Elixir v1.11.2 but it has
declared in its mix.exs file it supports only Elixir ~> 1.13

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Screenshots

Please attach screenshots and/or gifs of any visible changes to pages here.
