### PR TITLE
Add slack to "Contact Us" in footer

### DIFF
--- a/lib/erlef_web/templates/layout/footer.html.eex
+++ b/lib/erlef_web/templates/layout/footer.html.eex
@@ -79,6 +79,9 @@
             <div class="col-sm-3 pb-2">
               <span><a href="https://github.com/erlef"><i class="fab fa-lg fa-github fa-2x"></i></a></span>
             </div>
+            <div class="col-sm-3 pb-2">
+              <span><a href="https://erlef.org/slack-invite/erlef"><i class="fab fa-lg fa-slack fa-2x"></i></a></span>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Issue

* https://github.com/erlef/website/issues/366

Today I had the same problem like described in the issue. I think, adding a Slack icon to the "Contact Us" section in the footer should make the Slack invite page a lot more discoverable.

# Screenshots

![Screenshot from 2022-05-04 17-54-18](https://user-images.githubusercontent.com/426371/166721588-48e981de-8c6a-4dd7-b6e2-c05846ca4dbd.png)

The new Slack icon links to https://erlef.org/slack-invite/erlef