### PR TITLE
Fix sponsor logo misalignment

### DIFF
--- a/lib/erlef_web/templates/layout/footer.html.eex
+++ b/lib/erlef_web/templates/layout/footer.html.eex
@@ -8,7 +8,7 @@
        </div>
        <div class="row">
       <div class="col-lg-12 pr-5">
-        <div class="row text-center text-lg-left mt-3 mb-0">
+        <div class="row text-center text-lg-left mt-3 mb-3 d-flex align-items-center justify-content-center">
           <%= for %{logo_url: logo_path, url: href} <- active_and_founding_sponsors(@sponsors) do %>
             <div class="col-lg-1 col-md-3 col-sm-4">
               <a href="<%= href %>" class="d-block">

--- a/lib/erlef_web/templates/page/sponsors.html.eex
+++ b/lib/erlef_web/templates/page/sponsors.html.eex
@@ -11,7 +11,7 @@
         Our sponsors play a vital role in supporting the foundation's initiatives. It is through their generous donations that we can work on our mission to support and expand the Beam community.
         </p>
 
-        <div class="row text-center text-lg-left mt-3 mb-3">
+        <div class="row text-center text-lg-left mt-3 mb-3 d-flex align-items-center justify-content-center">
           <%= for %{logo_url: logo_path, url: href} <- active_and_founding_sponsors(@sponsors) do %>
             <div class="col-lg-2 col-md-4 col-6">
               <a href="<%= href %>" class="d-block mb-2">


### PR DESCRIPTION
- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Description

This MR adds Bootstrap CSS classes to fix misalignment issues when presenting sponsor logos. With the new CSS classes applied the logos are more evenly aligned on each row, leading to a cleaner presentation.

# Screenshots

## Sponsors page, old and new look

Old CSS classes
![erlef-old2](https://github.com/erlef/website/assets/3315272/82e41365-45c1-46cc-a127-62071e49c67e)

New CSS classes
![erlef-new2](https://github.com/erlef/website/assets/3315272/f41eab0e-2dd3-4220-bb9d-78795af30d96)

## Footer, old and new look

Old CSS classes
![erlef-old](https://github.com/erlef/website/assets/3315272/591ce9f8-c9e7-4f8d-a305-d25f40f4812d)

New CSS classes
![erlef-new](https://github.com/erlef/website/assets/3315272/0188ea85-23dc-4127-8530-97f92517657a)
