### PR TITLE
Change Mainmatter link

### DIFF
--- a/config/sponsors.exs
+++ b/config/sponsors.exs
@@ -274,7 +274,7 @@ config :erlef, :sponsors, [
     is_founding_sponsor: true,
     logo_url: "/images/sponsors/mainmatter-logo.png",
     name: "Mainmatter",
-    url: "https://mainmatter.com/"
+    url: "https://mainmatter.com/expertise/elixir-phoenix/"
   },
   %{
     active: true,


### PR DESCRIPTION
…to point to our Elixir-specific landing page.

- [x] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Screenshots

Sponsors page remains unchanged visually:

![Bildschirmfoto 2024-03-08 um 10 12 57](https://github.com/erlef/website/assets/1510/6941b3ce-5836-4d11-8ddb-6db095df50f2)
