### PR TITLE
Remove forced redirect on session expiration

### DIFF
--- a/lib/erlef_web/plugs/session.ex
+++ b/lib/erlef_web/plugs/session.ex
@@ -82,7 +82,5 @@ defmodule ErlefWeb.Plug.Session do
     conn
     |> delete_session("member_session")
     |> assign(:current_user, nil)
-    |> Phoenix.Controller.redirect(to: "/")
-    |> halt()
   end
 end


### PR DESCRIPTION
At least two stipend submitters have experienced an issue where the stipend form did not submit. One reported being redirect to the front page.

This behavior was confirmed by setting a lower expiration time on the fake WildApricot server. The stipend request would be lost if you spent more time on the page than remained in your current session. I don't know the default time for the real WildApricot but our dev server version has 30 minutes. It may take more time than that to write a proposal.

This commit removes the forced redirect when purging the session for the general Session Plug. This might seem concerning but should actually be more in line with the intent. The Session plug is used for many routes that do not require a session, such as the stipend page.

The check for pages that require authentication and authorization is handled in the Authz Plug which happens shortly after. I have tested this behavior on the News tips form as an example and it will warn that you need to log in if your session expires while submitting. You'd lose the form contents there.

This should address the risk of losing stipend requests to sessions timing out.

- [ ] I acknowledge my contribution to the website does not assert comparative or superlative differences of one product, project, company or individual over another.

# Screenshots

Please attach screenshots and/or gifs of any visible changes to pages here.
